### PR TITLE
兼容性改进，支持go modules方式安装

### DIFF
--- a/App/GetHot.go
+++ b/App/GetHot.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"../Common"
+	"github.com/tophubs/TopList/Common"
 	"bytes"
 	"encoding/json"
 	"fmt"

--- a/App/Server.go
+++ b/App/Server.go
@@ -6,9 +6,8 @@ import (
 	"net/http"
 	"regexp"
 	"text/template"
-
-	"../Common"
-	"../Config"
+	"github.com/tophubs/TopList/Common"
+	"github.com/tophubs/TopList/Config"
 )
 
 func GetTypeInfo(w http.ResponseWriter, r *http.Request) {

--- a/Common/Db.go
+++ b/Common/Db.go
@@ -1,7 +1,7 @@
 package Common
 
 import (
-	"../Config"
+	"github.com/tophubs/TopList/Config"
 	"database/sql"
 	"fmt"
 	_ "github.com/go-sql-driver/mysql"

--- a/Common/database.sql
+++ b/Common/database.sql
@@ -32,7 +32,7 @@ CREATE TABLE `hotData2` (
   PRIMARY KEY (`id`),
   KEY `hotData2__index_key` (`dataType`),
   KEY `hotData2__index_name` (`name`)
-) ENGINE=InnoDB AUTO_INCREMENT=114 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=114 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --

--- a/Config/mysql.toml
+++ b/Config/mysql.toml
@@ -1,2 +1,2 @@
-Source = "user:password@tcp(ip:port)/database?charset=utf8mb4"
+Source = "root:root@tcp(127.0.0.1:3306)/news?charset=utf8mb4"
 Driver = "mysql"

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,11 @@
+module github.com/tophubs/TopList
+
+go 1.13
+
+require (
+	github.com/BurntSushi/toml v0.3.1
+	github.com/PuerkitoBio/goquery v1.5.0 // indirect
+	github.com/bitly/go-simplejson v0.5.0 // indirect
+	github.com/go-sql-driver/mysql v1.4.1
+	golang.org/x/text v0.3.2 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,16 @@
+github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
+github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/PuerkitoBio/goquery v1.5.0 h1:uGvmFXOA73IKluu/F84Xd1tt/z07GYm8X49XKHP7EJk=
+github.com/PuerkitoBio/goquery v1.5.0/go.mod h1:qD2PgZ9lccMbQlc7eEOjaeRlFQON7xY8kdmcsrnKqMg=
+github.com/andybalholm/cascadia v1.0.0 h1:hOCXnnZ5A+3eVDX8pvgl4kofXv2ELss0bKcqRySc45o=
+github.com/andybalholm/cascadia v1.0.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
+github.com/bitly/go-simplejson v0.5.0 h1:6IH+V8/tVMab511d5bn4M7EwGXZf9Hj6i2xSwkNEM+Y=
+github.com/bitly/go-simplejson v0.5.0/go.mod h1:cXHtHw4XUPsvGaxgjIAn8PhEWG9NfngEKAMDJEczWVA=
+github.com/go-sql-driver/mysql v1.4.1 h1:g24URVg0OFbNUTx9qqY1IRZ9D9z3iPyi5zKhQZpNwpA=
+github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
+golang.org/x/net v0.0.0-20180218175443-cbe0f9307d01/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20181114220301-adae6a3d119a h1:gOpx8G595UYyvj8UK4+OFyY4rx037g3fmfhe5SasG3U=
+golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
+golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=


### PR DESCRIPTION
upgrade to work with go module (golang>1.12)
modify collation to work with legacy mysql 5.7.x(utf8mb4_0900_ai_ci not
exist)